### PR TITLE
Fix bootstrap 4 css class

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2342,7 +2342,7 @@
         if (element.hasClass('input-group')) {
             // in case there is more then one 'input-group-addon' Issue #48
             if (element.find('.datepickerbutton').length === 0) {
-                component = element.find('.input-group-addon');
+                component = element.find('.input-group-append');
             } else {
                 component = element.find('.datepickerbutton');
             }


### PR DESCRIPTION
Bootstrap v4 has a different css class for input group addons

https://getbootstrap.com/docs/4.1/components/input-group/