### PR TITLE
update package file to point to transpiled build

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "moment"
   ],
   "license": "MIT",
-  "main": "src/js/bootstrap-datetimepicker.js",
+  "main": "build/js/bootstrap-datetimepicker.min.js",
   "name": "pc-bootstrap4-datetimepicker",
   "repository": {
     "type": "git",


### PR DESCRIPTION
setting the main as the src file causes import statements to pull it and if using webpack and not running babel over your node_modules, will cause compile failure on ie 11, this change will update the package file to point to the built version instead of source.

This repo is no longer actively monitor or supported. All future work is being done to https://github.com/tempusdominus/bootstrap-3 
