### PR TITLE
Fix/view date update

### DIFF
--- a/src/js/bootstrap-datetimepicker.js
+++ b/src/js/bootstrap-datetimepicker.js
@@ -2323,7 +2323,10 @@
             }
 
             viewDate = parseInputDate(newDate);
+            
+            update();
             viewUpdate();
+            
             return picker;
         };
 


### PR DESCRIPTION
Currently when we set a `minDate` and `maxDate` away from the current date (today) and we go back to the input it always set the `viewDate` to today even if we use the setter. Because there is no update of the datetimepicker to redirect to the specified date. 